### PR TITLE
Add luminance calculations for Recs. 709 and 601

### DIFF
--- a/lib/chromatist.rb
+++ b/lib/chromatist.rb
@@ -1,3 +1,4 @@
+require "chromatist/color"
 require "chromatist/version"
 
 module Chromatist

--- a/lib/chromatist/color.rb
+++ b/lib/chromatist/color.rb
@@ -1,0 +1,19 @@
+class Chromatist::Color
+  def initialize
+    @red = 255.0
+    @green = 204.0
+    @blue = 0.0
+  end
+
+  # Calculate luminance according to Rec. 709 for high definition screens.
+  # (http://en.wikipedia.org/wiki/Luma_%28video%29)
+  def objective_luminance
+    (0.2126 * @red + 0.7152 * @green + 0.0722 * @blue) / 255
+  end
+
+  # Calculate perceived luminence according to Rec. 601 for standard definition
+  # screens. (http://en.wikipedia.org/wiki/Luma_%28video%29)
+  def perceived_luminance
+    (0.299 * @red + 0.587 * @green + 0.114 * @blue) / 255
+  end
+end


### PR DESCRIPTION
Implement calculations of [luminance](http://en.wikipedia.org/wiki/Luminance) for standard definition (perceived 
luminance) and high definition (objective luminance) based on [ITU-R](http://en.wikipedia.org/wiki/ITU-R) 
standards [Rec. 601](http://en.wikipedia.org/wiki/CCIR_601) and [Rec. 709](http://en.wikipedia.org/wiki/Rec._709), respectively.
- Introduce Chromatist::Color class to represent a color in the RGB
  color space and perform maths on it.
